### PR TITLE
New content for january

### DIFF
--- a/src/routes/Stats.jsx
+++ b/src/routes/Stats.jsx
@@ -119,7 +119,9 @@ export default function Stats() {
         </>
       )}
       {userData.data && userData.data.thisYear.Eau.allTasks.length === 0 && (
-        <p>Il n'y a pas de données à afficher</p>
+        <NoDataContant>
+          Les premières missions seront validées le premier février, nous comptons sur vous pour valider le plus de missions possible 💪
+        </NoDataContant>
       )}
     </div>
   )
@@ -164,4 +166,18 @@ const GraphContainerDesktop = styled.div`
 `
 const PageLocationContent = styled(PageLocation)`
   margin-bottom: 15px;
+`
+
+const NoDataContant = styled.div`
+  background-color: rgb(255,255,255);
+  box-shadow: 0px 0px 10px rgba(223,223,223,0.25);
+  padding: 13px 30%;
+  text-align: center;
+  display: flex;
+  align-items: center;
+  border-radius: 10px;
+  justify-content: center;
+  height: 60vh;
+  color: #AfAfAf;
+  font-family: 'Roboto', Arial, Helvetica, sans-serif;
 `

--- a/src/routes/Stats.jsx
+++ b/src/routes/Stats.jsx
@@ -119,9 +119,9 @@ export default function Stats() {
         </>
       )}
       {userData.data && userData.data.thisYear.Eau.allTasks.length === 0 && (
-        <NoDataContant>
+        <NoDataContent>
           Les premières missions seront validées le premier février, nous comptons sur vous pour valider le plus de missions possible 💪
-        </NoDataContant>
+        </NoDataContent>
       )}
     </div>
   )
@@ -168,7 +168,7 @@ const PageLocationContent = styled(PageLocation)`
   margin-bottom: 15px;
 `
 
-const NoDataContant = styled.div`
+const NoDataContent = styled.div`
   background-color: rgb(255,255,255);
   box-shadow: 0px 0px 10px rgba(223,223,223,0.25);
   padding: 13px 30%;


### PR DESCRIPTION
Ajout d'un container d'avertissement sur la page analytique quand nous sommes au mois de janvier afin de prévenir qu'il n'y a à pas encore de data pour ce mois si.

Version pc:
![Capture d’écran 2020-07-06 à 17 27 03](https://user-images.githubusercontent.com/20203227/86610638-ea566780-bfad-11ea-9451-38400e475013.png)

Version Mobile:
![Capture d’écran 2020-07-06 à 17 27 42](https://user-images.githubusercontent.com/20203227/86610709-01955500-bfae-11ea-8b8f-f95a5ee91da5.png)

